### PR TITLE
fix: pascal write中无分隔符

### DIFF
--- a/src/codeGenerate/cLangGenerator.cpp
+++ b/src/codeGenerate/cLangGenerator.cpp
@@ -913,7 +913,7 @@ std::string CLangGenerator::getCStyleIOFormatStr(
   std::string formatStr;
   for (size_t i = 0; i < types.size(); ++i) {
     formatStr += types[i]->visit(visitor);
-    // TODO: Pascal write 无分隔符
+    // Pascal write 无分隔符
   }
   return formatStr;
 }


### PR DESCRIPTION
# delete " "

## 描述
删除C语言输出中的分隔符

## 相关问题
无

## 检查清单
- [x] 我已测试了我的更改。
- [x] 我已更新相关文档（如适用）。
- [x] 我的代码符合项目的代码规范。
